### PR TITLE
Utilizing wakepy to prevent PC sleep

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import random
 import pygame
 import pyautogui
 import webbrowser
+from wakepy import keep
 
 MENTORSCRIPT_EVERYHOUR_URL = ""
 MENTORSCRIPT_EVERY30_URL = ""
@@ -172,5 +173,6 @@ class MentorScriptApp():
         self.root.mainloop()
 
 if __name__ == "__main__":
-    app = MentorScriptApp()
-    app.run()
+    with keep.running():
+        app = MentorScriptApp()
+        app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pygame
 pyautogui
+wakepy # This is to allow the python script to keep running and NOT shut down!!


### PR DESCRIPTION
This feature makes it where the Mentor Computer will **NOT** shut off or log off (as per RIT policy).

Further testing is required.. this PR is here to set it up first.